### PR TITLE
Wrong variable called for json output file

### DIFF
--- a/exodus_analyze.py
+++ b/exodus_analyze.py
@@ -47,7 +47,7 @@ if __name__ == '__main__':
 
     mode = 1
     if options.json_mode:
-        output = '%s.json' % options.output
+        output = '%s.json' % options.output_file
         mode = 2
 
     apk_file = args[0]


### PR DESCRIPTION
When using the json output option, it uses the wrong variable name, causing:
AttributeError: 'Values' object has no attribute 'output'