### PR TITLE
Fix a TypeError: Object of type 'bytes' is not JSON serializable

### DIFF
--- a/exodus_analyze.py
+++ b/exodus_analyze.py
@@ -14,7 +14,7 @@ class AnalysisHelper(StaticAnalysis):
                 'uaid': self.get_application_universal_id(),
                 'name': self.get_app_name(),
                 'permissions': self.get_permissions(),
-                'libraries': self.get_libraries(),
+                'libraries': [l.decode('utf-8') for l in self.get_libraries()],
             },
             'apk': {
                 'path': self.apk_path,


### PR DESCRIPTION
On ArchLinux, using a python3 virtualenv as described in the README, asking a json output for a static analysis crash with a type error.

A txt output show the following:

```
…
- App libraries: 1
    - b'com.sec.android.app.multiwindow'
…
```

Thus, I just convert the get_libraries output from an array of bytes to an array of string.

Dexdump binary used is from the android SDK v. 27.0.3

The crash stack trace is:

```
$ python exodus_analyze.py -j ~/latest.apk
Traceback (most recent call last):
  File "exodus_analyze.py", line 62, in <module>
    report = json.dumps(analysis.create_json_report(), indent = 2)
  File "/usr/lib64/python3.6/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "/usr/lib64/python3.6/json/encoder.py", line 201, in encode
    chunks = list(chunks)
  File "/usr/lib64/python3.6/json/encoder.py", line 430, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/usr/lib64/python3.6/json/encoder.py", line 404, in _iterencode_dict
    yield from chunks
  File "/usr/lib64/python3.6/json/encoder.py", line 404, in _iterencode_dict
    yield from chunks
  File "/usr/lib64/python3.6/json/encoder.py", line 325, in _iterencode_list
    yield from chunks
  File "/usr/lib64/python3.6/json/encoder.py", line 437, in _iterencode
    o = _default(o)
  File "/usr/lib64/python3.6/json/encoder.py", line 180, in default
    o.__class__.__name__)
TypeError: Object of type 'bytes' is not JSON serializable
```