### PR TITLE
chore(deps): Bump exodus-core from 1.2.0 to 1.3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-exodus-core==1.2.0
+exodus-core==1.3.4


### PR DESCRIPTION
## Changelogs

```
1192a81 Bump cryptography from 2.6.1 to 3.2
2491efd Clean requirements & remove GPlayCli
6855729 Remove Gplaycli configuration
a173d13 Fix 'ResourceWarning: unclosed file' with PIL.Image
4deaa5a Add Dockerfile for testing purposes
e145fc0 Removes internet download of app icon (#41)
9dae650 Fix issues with new version of flake8
421ec74 Refacto & better errors management for connector.py
f57823d Bump Pillow to 6.2.2
405ad4b Fix bug with apps when icon cannot be get from APK
3d7ef32 replace %s by {} (#12)
19b1ffe Update README following pypi deployment
b154bc4 Test deployment to pypi
64da3a0 Add LGTM badge to README
110e577 Comment out unused gplaycli code
20b95a7 Fix couple of flake8 non compliance
```