### PR TITLE
[CI] Add Python 3.12 and 3.13 tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,15 +10,23 @@ on:
       - master
   workflow_dispatch:
 
+
 jobs:
   test:
+    name: test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - 3.11
+          - 3.12
+          - 3.13
     steps:
       - uses: actions/checkout@v4
-      - name: Set up python 3.11
+      - name: Set up python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
# Goal

- Add Python `3.12` and `3.13` CI tests